### PR TITLE
Make a flake of it to improve reproducibility

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,81 @@
+{
+  "nodes": {
+    "gst-libvncclient-rfbsrc": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1588455169,
+        "narHash": "sha256-P/s0RhY04BCHmUIHamKWgAIGxlHYUf99Im/8j0s2DUY=",
+        "owner": "peter-sa",
+        "repo": "gst-libvncclient-rfbsrc",
+        "rev": "399c634cf5cd7afc649df15861fe9f463c4249e0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "peter-sa",
+        "ref": "v0.0.1",
+        "repo": "gst-libvncclient-rfbsrc",
+        "type": "github"
+      }
+    },
+    "mxc_epdc_fb_damage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1588455209,
+        "narHash": "sha256-ewvHqQz5HMTMPAysYQYdeCCKlgqqFQz1x1Mnnlzyvd4=",
+        "owner": "peter-sa",
+        "repo": "mxc_epdc_fb_damage",
+        "rev": "8b9405a924bf105c0d3e3b51ed47128f66521f50",
+        "type": "github"
+      },
+      "original": {
+        "owner": "peter-sa",
+        "ref": "v0.0.1",
+        "repo": "mxc_epdc_fb_damage",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1604062258,
+        "narHash": "sha256-mxaFpiXn8AxYkjkP2SpabPYInFnzdHCGaXu8SOBE3Jk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ebe09a7ccc634bfad03d21e7a5f25923a451d875",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ebe09a7ccc634bfad03d21e7a5f25923a451d875",
+        "type": "github"
+      }
+    },
+    "rM-vnc-server": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1588455269,
+        "narHash": "sha256-Y1z69KvOFsBLHe0ixbYlyILV09kSGaJ+ooDE/dlT2Sw=",
+        "owner": "peter-sa",
+        "repo": "rM-vnc-server",
+        "rev": "3beb2988062c939c1e84c3c3b780e209d22cccab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "peter-sa",
+        "ref": "v0.0.1",
+        "repo": "rM-vnc-server",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "gst-libvncclient-rfbsrc": "gst-libvncclient-rfbsrc",
+        "mxc_epdc_fb_damage": "mxc_epdc_fb_damage",
+        "nixpkgs": "nixpkgs",
+        "rM-vnc-server": "rM-vnc-server"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,7 @@
       packages.x86_64-linux = {
         inherit (rmPkgs.linuxPackages) mxc_epdc_fb_damage;
         inherit (rmPkgs) rM-vnc-server chessmarkable retris evkill;
+        inherit (rmPkgs) remarkable-fractals remarkable_news;
         inherit (hostPkgs) gst-libvncclient-rfbsrc;
       };
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,31 @@
+{
+  description = "Various programs for the reMarkable tablet";
+
+  inputs.nixpkgs.url = github:NixOS/nixpkgs/ebe09a7ccc634bfad03d21e7a5f25923a451d875;
+  inputs.mxc_epdc_fb_damage.url = github:peter-sa/mxc_epdc_fb_damage/v0.0.1;
+  inputs.mxc_epdc_fb_damage.flake = false;
+  inputs.rM-vnc-server.url = github:peter-sa/rM-vnc-server/v0.0.1;
+  inputs.rM-vnc-server.flake = false;
+  inputs.gst-libvncclient-rfbsrc.url = github:peter-sa/gst-libvncclient-rfbsrc/v0.0.1;
+  inputs.gst-libvncclient-rfbsrc.flake = false;
+
+  outputs = srcs1@{ self, nixpkgs, ... }:
+    let
+      srcs = builtins.mapAttrs (k: v: v // { drv = v + "/derivation.nix"; }) srcs1;
+      rmPkgs = import ./rM { inherit srcs hostPkgs; };
+      hostPkgs = import ./host { inherit srcs rmPkgs; };
+    in
+    {
+
+      # packages.x86_64-linux = { rmPkgs = rmPkgs.recurseIntoAttrs rmPkgs; };
+      packages.x86_64-linux = {
+        inherit (rmPkgs.linuxPackages) mxc_epdc_fb_damage;
+        inherit (rmPkgs) rM-vnc-server chessmarkable retris evkill;
+        inherit (hostPkgs) gst-libvncclient-rfbsrc;
+      };
+
+      # packages.x86_64-linux.hello = nixpkgs.legacyPackages.x86_64-linux.hello;
+      # defaultPackage.x86_64-linux = self.packages.x86_64-linux.hello;
+
+    };
+}

--- a/host/default.nix
+++ b/host/default.nix
@@ -1,6 +1,7 @@
 { srcs, rmPkgs }: with srcs;
 
 import nixpkgs {
+  system = "x86_64-linux";
   overlays = [
     (self: super: { inherit rmPkgs; })
     (import ./packages.nix srcs)


### PR DESCRIPTION

You can build packages with, e.g.
```
nix build --system x86_64-linux -L .#chessmarkable
nix build --system x86_64-linux -L .#retris
nix build --system x86_64-linux -L .#rM-vnc-server
```
etc.

Note that the flake version is missing some features of the non-flake version in `default.nix`. It is also duplicating code from `srcs.nix`.