### PR TITLE
Flakes: Build the linux version on MacOS too

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,10 @@
 
       packages.x86_64-darwin = self.packages.x86_64-linux;
 
+      overlay = final: prev: {
+        inherit rmPkgs hostPkgs;
+      };
+
       # packages.x86_64-linux.hello = nixpkgs.legacyPackages.x86_64-linux.hello;
       # defaultPackage.x86_64-linux = self.packages.x86_64-linux.hello;
 

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,8 @@
       packages.x86_64-linux = {
         inherit (rmPkgs.linuxPackages) mxc_epdc_fb_damage;
         inherit (rmPkgs) rM-vnc-server chessmarkable retris evkill;
-        inherit (rmPkgs) remarkable-fractals remarkable_news;
+        inherit (rmPkgs) remarkable_news;
+        # inherit (rmPkgs) remarkable-fractals;
         inherit (hostPkgs) gst-libvncclient-rfbsrc;
       };
 

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,8 @@
         inherit (hostPkgs) gst-libvncclient-rfbsrc;
       };
 
+      packages.x86_64-darwin = self.packages.x86_64-linux;
+
       # packages.x86_64-linux.hello = nixpkgs.legacyPackages.x86_64-linux.hello;
       # defaultPackage.x86_64-linux = self.packages.x86_64-linux.hello;
 


### PR DESCRIPTION
Now we can build packages with just:
```
nix-build .#retris
etc.
```
without specifying `--system x86_64-linux`. This also means that remote-building works.